### PR TITLE
Copy the invocation scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,13 @@ execute_process(
 
 include(FindGMP)
 
+execute_process(
+  COMMAND ${LLVM_CONFIG_EXECUTABLE} --bindir
+  OUTPUT_VARIABLE LLVM_BINDIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+set(CLANG "${LLVM_BINDIR}/clang")
 configure_file(${CMAKE_SOURCE_DIR}/kittel-llvm.in ${CMAKE_BINARY_DIR}/kittel-llvm @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/kittel-llvm-bounded.in ${CMAKE_BINARY_DIR}/kittel-llvm-bounded @ONLY)
 

--- a/kittel-llvm-bounded.in
+++ b/kittel-llvm-bounded.in
@@ -5,7 +5,7 @@ BBASENAME=$BASENAME-bounded
 shift
 
 echo "Calling clang"
-clang-3.4 -Wall -Wextra -c -emit-llvm -O0 $FULLNAME -o $BASENAME.bc
+@CLANG@ -Wall -Wextra -c -emit-llvm -O0 $FULLNAME -o $BASENAME.bc
 if [ $? != 0 ]
 then
   exit 1
@@ -29,3 +29,4 @@ then
 else
   echo "shown"
 fi
+

--- a/kittel-llvm.in
+++ b/kittel-llvm.in
@@ -4,7 +4,7 @@ BASENAME=`basename $1 .c`
 shift
 
 echo "Calling clang"
-clang-3.4 -Wall -Wextra -c -emit-llvm -O0 $FULLNAME -o $BASENAME.bc
+@CLANG@ -Wall -Wextra -c -emit-llvm -O0 $FULLNAME -o $BASENAME.bc
 if [ $? != 0 ]
 then
   exit 1
@@ -28,3 +28,4 @@ then
 else
   echo "shown"
 fi
+


### PR DESCRIPTION
This copies the invocation scripts to the build directory in case of an out-of-tree build. To avoid problems with in-tree builds, rename the original scripts. This also creates the opportunity to plug in the full path to clang (assuming its path corresponds to the path used for the llvm binaries).
