### PR TITLE
Handle vector arithmetic

### DIFF
--- a/include/llvm2kittel/Analysis/InstChecker.h
+++ b/include/llvm2kittel/Analysis/InstChecker.h
@@ -47,6 +47,8 @@ public:
     void visitMul(llvm::BinaryOperator &I);
     void visitSDiv(llvm::BinaryOperator &I);
     void visitSRem(llvm::BinaryOperator &I);
+    void visitUDiv(llvm::BinaryOperator &I);
+    void visitURem(llvm::BinaryOperator &I);
 
     void visitAnd(llvm::BinaryOperator &I);
     void visitOr(llvm::BinaryOperator &I);

--- a/lib/Analysis/InstChecker.cpp
+++ b/lib/Analysis/InstChecker.cpp
@@ -47,35 +47,49 @@ void InstChecker::visitTerminatorInst(llvm::TerminatorInst &I)
 
 void InstChecker::visitAdd(llvm::BinaryOperator &I)
 {
-    if (!llvm::isa<llvm::IntegerType>(I.getType())) {
+    if (!I.getType()->isIntegerTy() && !I.getType()->isVectorTy()) {
         addUnsuitable(I);
     }
 }
 
 void InstChecker::visitSub(llvm::BinaryOperator &I)
 {
-    if (!llvm::isa<llvm::IntegerType>(I.getType())) {
+    if (!I.getType()->isIntegerTy() && !I.getType()->isVectorTy()) {
         addUnsuitable(I);
     }
 }
 
 void InstChecker::visitMul(llvm::BinaryOperator &I)
 {
-    if (!llvm::isa<llvm::IntegerType>(I.getType())) {
+    if (!I.getType()->isIntegerTy() && !I.getType()->isVectorTy()) {
         addUnsuitable(I);
     }
 }
 
 void InstChecker::visitSDiv(llvm::BinaryOperator &I)
 {
-    if (!llvm::isa<llvm::IntegerType>(I.getType())) {
+    if (!I.getType()->isIntegerTy() && !I.getType()->isVectorTy()) {
         addUnsuitable(I);
     }
 }
 
 void InstChecker::visitSRem(llvm::BinaryOperator &I)
 {
-    if (!llvm::isa<llvm::IntegerType>(I.getType())) {
+    if (!I.getType()->isIntegerTy()) {
+        addUnsuitable(I);
+    }
+}
+
+void InstChecker::visitUDiv(llvm::BinaryOperator &I)
+{
+    if (!I.getType()->isIntegerTy() && !I.getType()->isVectorTy()) {
+        addUnsuitable(I);
+    }
+}
+
+void InstChecker::visitURem(llvm::BinaryOperator &I)
+{
+    if (!I.getType()->isIntegerTy()) {
         addUnsuitable(I);
     }
 }
@@ -163,7 +177,7 @@ void InstChecker::visitSelectInst(llvm::SelectInst &I)
 
 void InstChecker::visitPHINode(llvm::PHINode &I)
 {
-    if (I.getType()->isFloatTy() || I.getType()->isDoubleTy() || llvm::isa<llvm::PointerType>(I.getType())) {
+    if (I.getType()->isFloatTy() || I.getType()->isDoubleTy() || I.getType()->isPointerTy() || I.getType()->isVectorTy()) {
         return;
     }
     if (!llvm::isa<llvm::IntegerType>(I.getType())) {

--- a/lib/Core/Converter.cpp
+++ b/lib/Core/Converter.cpp
@@ -796,7 +796,7 @@ void Converter::visitGenericInstruction(llvm::Instruction &I, ref<Polynomial> va
 
 void Converter::visitAdd(llvm::BinaryOperator &I)
 {
-    if (I.getType() == m_boolType) {
+    if (I.getType() == m_boolType || I.getType()->isVectorTy()) {
         return;
     }
     if (m_phase1) {
@@ -810,7 +810,7 @@ void Converter::visitAdd(llvm::BinaryOperator &I)
 
 void Converter::visitSub(llvm::BinaryOperator &I)
 {
-    if (I.getType() == m_boolType) {
+    if (I.getType() == m_boolType || I.getType()->isVectorTy()) {
         return;
     }
     if (m_phase1) {
@@ -824,7 +824,7 @@ void Converter::visitSub(llvm::BinaryOperator &I)
 
 void Converter::visitMul(llvm::BinaryOperator &I)
 {
-    if (I.getType() == m_boolType) {
+    if (I.getType() == m_boolType || I.getType()->isVectorTy()) {
         return;
     }
     if (m_phase1) {
@@ -1010,7 +1010,7 @@ ref<Constraint> Converter::getExactSDivConstraintForUnbounded(ref<Polynomial> up
 
 void Converter::visitSDiv(llvm::BinaryOperator &I)
 {
-    if (I.getType() == m_boolType) {
+    if (I.getType() == m_boolType || I.getType()->isVectorTy()) {
         return;
     }
     if (m_phase1) {
@@ -1105,7 +1105,7 @@ ref<Constraint> Converter::getExactUDivConstraintForUnbounded(ref<Polynomial> up
 
 void Converter::visitUDiv(llvm::BinaryOperator &I)
 {
-    if (I.getType() == m_boolType) {
+    if (I.getType() == m_boolType || I.getType()->isVectorTy()) {
         return;
     }
     if (m_phase1) {


### PR DESCRIPTION
It is handled by ignoring it. While we're editing this code add InstChecker calls for UDiv and URem.

I never encountered vector SRem and URem. Hence, these are still caught as unsuitable.
