### PR TITLE
Let div and rem return a nondef without constraints

### DIFF
--- a/include/llvm2kittel/Converter.h
+++ b/include/llvm2kittel/Converter.h
@@ -49,7 +49,7 @@ class Converter : public llvm::InstVisitor<Converter>
 #include "WARN_ON.h"
 
 public:
-    Converter(const llvm::Type *boolType, bool assumeIsControl, bool selectIsControl, bool onlyMultiPredIsControl, bool boundedIntegers, bool unsignedEncoding, bool onlyLoopConditions, bool exactDivision, bool bitwiseConditions, bool complexityTuples);
+    Converter(const llvm::Type *boolType, bool assumeIsControl, bool selectIsControl, bool onlyMultiPredIsControl, bool boundedIntegers, bool unsignedEncoding, bool onlyLoopConditions, bool exactDivision, bool dumbDivision, bool bitwiseConditions, bool complexityTuples);
 
     void phase1(llvm::Function *function, std::set<llvm::Function*> &scc, MayMustMap &mmMap, std::map<llvm::Function*, std::set<llvm::GlobalVariable*> > &funcMayZap, TrueFalseMap &tfMap, std::set<llvm::BasicBlock*> &lcbs, ConditionMap &elcMap);
     void phase2(llvm::Function *function, std::set<llvm::Function*> &scc, MayMustMap &mmMap, std::map<llvm::Function*, std::set<llvm::GlobalVariable*> > &funcMayZap, TrueFalseMap &tfMap, std::set<llvm::BasicBlock*> &lcbs, ConditionMap &elcMap);
@@ -203,6 +203,7 @@ private:
     std::set<llvm::BasicBlock*> m_loopConditionBlocks;
 
     bool m_exactDivision;
+    bool m_dumbDivision;
 
     bool m_bitwiseConditions;
 

--- a/tools/llvm2kittel.cpp
+++ b/tools/llvm2kittel.cpp
@@ -99,6 +99,7 @@ static cl::opt<bool> explicitizeLoopConditions("explicitize-loop-conditions", cl
 static cl::opt<bool> simplifyConds("simplify-conditions", cl::desc("Simplify conditions in the generated TRS"), cl::init(false));
 static cl::opt<bool> onlyLoopConditions("only-loop-conditions", cl::desc("Only encode loop conditions in the generated TRS"), cl::init(false));
 static cl::opt<bool> exactDivision("exact-division", cl::desc("Give tighter approximation of divions (only for mathematical integers)"), cl::init(false));
+static cl::opt<bool> dumbDivision("dumb-division", cl::desc("Division just yields nondef"), cl::init(false));
 static cl::opt<bool> bitwiseConditions("bitwise-conditions", cl::desc("Add conditions for bitwise & and |"), cl::init(false));
 
 static cl::opt<bool> dumpLL("dump-ll", cl::desc("Dump transformed bitcode into a file"), cl::init(false));
@@ -568,7 +569,7 @@ int main(int argc, char *argv[])
 
         for (std::list<llvm::Function*>::iterator fi = scc.begin(), fe = scc.end(); fi != fe; ++fi) {
             llvm::Function *curr = *fi;
-            Converter converter(boolType, assumeIsControl, selectIsControl, onlyMultiPredIsControl, boundedIntegers, unsignedEncoding, onlyLoopConditions, exactDivision, bitwiseConditions, complexityTuples || uniformComplexityTuples);
+            Converter converter(boolType, assumeIsControl, selectIsControl, onlyMultiPredIsControl, boundedIntegers, unsignedEncoding, onlyLoopConditions, exactDivision, dumbDivision, bitwiseConditions, complexityTuples || uniformComplexityTuples);
             std::map<llvm::Function*, MayMustMap>::iterator tmp1 = mmMap.find(curr);
             if (tmp1 == mmMap.end()) {
                 std::cerr << "Could not find alias information (" << __FILE__ << ":" << __LINE__ << ")!" << std::endl;


### PR DESCRIPTION
This needs some work before it can be merged. The idea is to provide a coarser abstraction for divisions than the one that is usually used. The coarser abstraction is to generate no constraints at all.

This had some use to me in cases where many div's and rem's occurred, but none were crucial for showing termination.

Problems with the current code:
- This needs a better name than "dumb division"
- This probably works in combination with bounded integers, but it currently does not.

Some feedback on the above issues is more than welcome. 
