### PR TITLE
Fix for crash in loop condition blocks collector

### DIFF
--- a/include/llvm2kittel/Analysis/LoopConditionBlocksCollector.h
+++ b/include/llvm2kittel/Analysis/LoopConditionBlocksCollector.h
@@ -42,6 +42,8 @@ public:
         return "Collect loop condition blocks";
     }
 
+    virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
+
     static char ID;
 
     std::set<llvm::BasicBlock*> getLoopConditionBlocks()

--- a/lib/Analysis/LoopConditionBlocksCollector.cpp
+++ b/lib/Analysis/LoopConditionBlocksCollector.cpp
@@ -18,6 +18,11 @@ LoopConditionBlocksCollector::LoopConditionBlocksCollector()
 LoopConditionBlocksCollector::~LoopConditionBlocksCollector()
 {}
 
+void LoopConditionBlocksCollector::getAnalysisUsage(llvm::AnalysisUsage &AU) const
+{
+    AU.addRequired<llvm::LoopInfo>();
+}
+
 bool LoopConditionBlocksCollector::runOnLoop(llvm::Loop *L, llvm::LPPassManager&)
 {
     llvm::BasicBlock *header = L->getHeader();


### PR DESCRIPTION
The loop condition block collector depends on the Loop Info pass. A crash occurs with LLVM 3.4 and 3.5 if this dependence is not specified. I could not test with earlier versions of LLVM, but compilation does succeed against LLVM 2.9.

I believe this is the last of the generic changes in my private repository.
