### PR TITLE
Enable building against LLVM 3.8

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -3,7 +3,7 @@ Requirements:
 
   * A C++ compiler (both gcc and clang have been tested).
   * LLVM (versions 2.9 and 3.4 have been tested, but versions 3.0, 3.1,
-          3.2, 3.3, 3.5, and 3.6 should also work).
+          3.2, 3.3, 3.5, 3.6, and 3.7 should also work).
   * GMP
 
 Build instructions:

--- a/INSTALL
+++ b/INSTALL
@@ -3,7 +3,7 @@ Requirements:
 
   * A C++ compiler (both gcc and clang have been tested).
   * LLVM (versions 2.9 and 3.4 have been tested, but versions 3.0, 3.1,
-          3.2, 3.3, 3.5, 3.6, and 3.7 should also work).
+          3.2, 3.3, 3.5, 3.6, 3.7, and 3.8 should also work).
   * GMP
 
 Build instructions:

--- a/include/llvm2kittel/Util/CommandLine.h
+++ b/include/llvm2kittel/Util/CommandLine.h
@@ -437,15 +437,15 @@ struct OptionValue : OptionValueBase<DataType, IS_CLASS<DataType>::value> {
 // Other safe-to-copy-by-value common option types.
 enum boolOrDefault { BOU_UNSET, BOU_TRUE, BOU_FALSE };
 template<>
-struct OptionValue<cl::boolOrDefault> : OptionValueCopy<cl::boolOrDefault> {
-  typedef cl::boolOrDefault WrapperType;
+struct OptionValue<boolOrDefault> : OptionValueCopy<boolOrDefault> {
+  typedef boolOrDefault WrapperType;
 
   OptionValue() {}
 
-  OptionValue(const cl::boolOrDefault& V) {
+  OptionValue(const boolOrDefault& V) {
     this->setValue(V);
   }
-  OptionValue<cl::boolOrDefault> &operator=(const cl::boolOrDefault& V) {
+  OptionValue<boolOrDefault> &operator=(const boolOrDefault& V) {
     setValue(V);
     return *this;
   }
@@ -1185,7 +1185,7 @@ class opt : public Option,
 
   virtual void printOptionValue(size_t GlobalWidth, bool Force) const {
     if (Force || this->getDefault().compare(this->getValue())) {
-      cl::printOptionDiff<ParserClass>(
+      printOptionDiff<ParserClass>(
         *this, Parser, this->getValue(), this->getDefault(), GlobalWidth);
     }
   }

--- a/lib/Analysis/ConditionPropagator.cpp
+++ b/lib/Analysis/ConditionPropagator.cpp
@@ -97,14 +97,14 @@ bool ConditionPropagator::runOnFunction(llvm::Function &F)
         std::cout << "========================================" << std::endl;
     }
     for (llvm::Function::iterator bbi = F.begin(), bbe = F.end(); bbi != bbe; ++bbi) {
-        llvm::BasicBlock *bb = bbi;
+        llvm::BasicBlock *bb = &*bbi;
         std::set<llvm::BasicBlock*> preds;
         for (llvm::Function::iterator tmpi = F.begin(), tmpe = F.end(); tmpi != tmpe; ++tmpi) {
-            if (isPred(tmpi, bb) && backedges.find(std::make_pair(tmpi, bb)) == backedges.end()) {
+            if (isPred(&*tmpi, bb) && backedges.find(std::make_pair(&*tmpi, bb)) == backedges.end()) {
                 if (m_debug) {
                     std::cout << bb->getName().str() << " has non-backedge predecessor " << tmpi->getName().str() << std::endl;
                 }
-                preds.insert(tmpi);
+                preds.insert(&*tmpi);
             }
         }
         std::set<llvm::Value*> trueSet;

--- a/lib/Analysis/HierarchyBuilder.cpp
+++ b/lib/Analysis/HierarchyBuilder.cpp
@@ -42,9 +42,9 @@ void HierarchyBuilder::computeHierarchy(llvm::Module *module)
     }
     for (llvm::Module::iterator i = module->begin(), e = module->end(); i != e; ++i) {
         if (!i->isDeclaration()) {
-            m_functionIdx.insert(std::make_pair(i, m_numFunctions));
-            m_idxFunction.insert(std::make_pair(m_numFunctions, i));
-            m_functions.push_back(i);
+            m_functionIdx.insert(std::make_pair(&*i, m_numFunctions));
+            m_idxFunction.insert(std::make_pair(m_numFunctions, &*i));
+            m_functions.push_back(&*i);
             ++m_numFunctions;
         }
     }

--- a/lib/Core/Slicer.cpp
+++ b/lib/Core/Slicer.cpp
@@ -138,7 +138,7 @@ std::list<ref<Rule> > Slicer::sliceUsage(std::list<ref<Rule> > rules)
     // Keep all inputs of integer type
     unsigned int intarg = 0;
     for (llvm::Function::arg_iterator i = m_F->arg_begin(), e = m_F->arg_end(); i != e; ++i) {
-        llvm::Argument *arg = i;
+        llvm::Argument *arg = &*i;
         if (llvm::isa<llvm::IntegerType>(arg->getType())) {
             notNeeded.erase(intarg);
             intarg++;
@@ -185,7 +185,7 @@ std::list<ref<Rule> > Slicer::sliceConstraint(std::list<ref<Rule> > rules)
     // Keep all inputs of integer type
     unsigned int intarg = 0;
     for (llvm::Function::arg_iterator i = m_F->arg_begin(), e = m_F->arg_end(); i != e; ++i) {
-        llvm::Argument *arg = i;
+        llvm::Argument *arg = &*i;
         if (llvm::isa<llvm::IntegerType>(arg->getType())) {
             notNeeded.erase(intarg);
             intarg++;

--- a/lib/Transform/BitcastCallEliminator.cpp
+++ b/lib/Transform/BitcastCallEliminator.cpp
@@ -21,10 +21,10 @@ bool BitcastCallEliminator::runOnFunction(llvm::Function &function)
     while (doLoop) {
         doLoop = false;
         for (llvm::Function::iterator i = function.begin(), e = function.end(); i != e; ++i) {
-            llvm::BasicBlock *bb = i;
+            llvm::BasicBlock *bb = &*i;
             bool bbchanged = false;
             for (llvm::BasicBlock::iterator ibb = bb->begin(), ebb = bb->end(); ibb != ebb; ++ibb) {
-                llvm::Instruction *inst = ibb;
+                llvm::Instruction *inst = &*ibb;
                 if (llvm::isa<llvm::CallInst>(inst) && llvm::cast<llvm::CallInst>(inst)->getCalledFunction() == NULL) {
                     llvm::CallInst *callInst = llvm::cast<llvm::CallInst>(inst);
                     llvm::Value *calledValue = callInst->getCalledValue();

--- a/lib/Transform/ConstantExprEliminator.cpp
+++ b/lib/Transform/ConstantExprEliminator.cpp
@@ -21,10 +21,10 @@ bool ConstantExprEliminator::runOnFunction(llvm::Function &function)
     while (doLoop) {
         doLoop = false;
         for (llvm::Function::iterator i = function.begin(), e = function.end(); i != e; ++i) {
-            llvm::BasicBlock *bb = i;
+            llvm::BasicBlock *bb = &*i;
             bool bbchanged = false;
             for (llvm::BasicBlock::iterator ibb = bb->begin(), ebb = bb->end(); ibb != ebb; ++ibb) {
-                llvm::Instruction *inst = ibb;
+                llvm::Instruction *inst = &*ibb;
                 unsigned int n = inst->getNumOperands();
                 for (unsigned int j = 0; j < n; ++j) {
                     llvm::Value *arg = inst->getOperand(j);

--- a/lib/Transform/EagerInliner.cpp
+++ b/lib/Transform/EagerInliner.cpp
@@ -49,8 +49,11 @@ llvm::Pass *createEagerInlinerPass()
 #else
     llvm::initializeCallGraphWrapperPassPass(*llvm::PassRegistry::getPassRegistry());
 #endif
-#if LLVM_VERSION >= VERSION(3, 6)
+#if LLVM_VERSION >= VERSION(3, 6) && LLVM_VERSION < VERSION(3, 8)
     llvm::initializeAliasAnalysisAnalysisGroup(*llvm::PassRegistry::getPassRegistry());
+    llvm::initializeAssumptionCacheTrackerPass(*llvm::PassRegistry::getPassRegistry());
+#elif LLVM_VERSION >= VERSION(3, 8)
+    llvm::initializeAAResultsWrapperPassPass(*llvm::PassRegistry::getPassRegistry());
     llvm::initializeAssumptionCacheTrackerPass(*llvm::PassRegistry::getPassRegistry());
 #endif
     return new EagerInliner();

--- a/lib/Transform/ExtremeInliner.cpp
+++ b/lib/Transform/ExtremeInliner.cpp
@@ -64,8 +64,11 @@ llvm::Pass *createExtremeInlinerPass(llvm::Function *function, bool inlineVoids)
 #else
     llvm::initializeCallGraphWrapperPassPass(*llvm::PassRegistry::getPassRegistry());
 #endif
-#if LLVM_VERSION >= VERSION(3, 6)
+#if LLVM_VERSION >= VERSION(3, 6) && LLVM_VERSION < VERSION(3, 8)
     llvm::initializeAliasAnalysisAnalysisGroup(*llvm::PassRegistry::getPassRegistry());
+    llvm::initializeAssumptionCacheTrackerPass(*llvm::PassRegistry::getPassRegistry());
+#elif LLVM_VERSION >= VERSION(3, 8)
+    llvm::initializeAAResultsWrapperPassPass(*llvm::PassRegistry::getPassRegistry());
     llvm::initializeAssumptionCacheTrackerPass(*llvm::PassRegistry::getPassRegistry());
 #endif
     return new ExtremeInliner(function, inlineVoids);

--- a/tools/llvm2kittel.cpp
+++ b/tools/llvm2kittel.cpp
@@ -233,7 +233,11 @@ void transformModule(llvm::Module *module, llvm::Function *function, NondefFacto
     llvmPasses.add(createBasicBlockSorterPass());
 
     // Alias analysis
+#if LLVM_VERSION < VERSION(3, 8)
     llvmPasses.add(llvm::createBasicAliasAnalysisPass());
+#else
+    llvmPasses.add(llvm::createBasicAAWrapperPass());
+#endif
 
     // lastly, do some verification of the modified code
     llvmPasses.add(llvm::createVerifierPass());
@@ -287,7 +291,11 @@ std::pair<MayMustMap, std::set<llvm::GlobalVariable*> > getMayMustMap(llvm::Func
     }
 #endif
 
+#if LLVM_VERSION < VERSION(3, 8)
     PM.add(llvm::createBasicAliasAnalysisPass());
+#else
+    PM.add(llvm::createBasicAAWrapperPass());
+#endif
 
     MemoryAnalyzer *maPass = createMemoryAnalyzerPass();
     PM.add(maPass);
@@ -467,16 +475,16 @@ int main(int argc, char *argv[])
 
     for (llvm::Module::iterator i = module->begin(), e = module->end(); i != e; ++i) {
         if (i->getName() == functionname) {
-            function = i;
+            function = &*i;
             break;
         } else if (functionname.empty() && i->getName() == "main") {
-            function = i;
+            function = &*i;
             break;
         } else if (!i->isDeclaration()) {
             ++numFunctions;
             functionNames.push_back(i->getName());
             if (firstFunction == NULL) {
-                firstFunction = i;
+                firstFunction = &*i;
             }
         }
     }


### PR DESCRIPTION
Changes are as follows:

* Update documentation to mention LLVM 3.7 and 3.8
* Implicit casting from iterators to other types is no longer allowed in LLVM 3.8, make the casting explicit (these are all the `&*` related changes). This would also work with earlier versions and, hence, is not if-def'ed.
* Replace `preheader->getInstList().insert(preheader->getTerminator(), &I);` with `I.insertBefore(preheader->getTerminator());` This avoid going through an iterator (see previous point) and is much clearer. Looking back to LLVM 2.9, I see that `insertBefore` was already available.
* Remove some explicit namespace mentions in CommandLine.h. The official CommandLine.h is pull ed in somehow and that was causing conflicts.
* Adapt code for handling LLVM 3.8 style alias analysis.

Two notes:
* I only tried to compile against LLVM 3.7 and 3.8. This should probably be sanity checked against 2.9 and 3.4 at least.
* I mostly tested this against GPU kernels, for which I skip the passes that use alias analysis. It would be good to test this with some examples that do use the affected passes.