### PR TITLE
Make compile against LLVM 4.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -3,7 +3,7 @@ Requirements:
 
   * A C++ compiler (both gcc and clang have been tested).
   * LLVM (versions 2.9 and 3.4 have been tested, but all versions from 2.9
-          up to and including 3.9 should work).
+          up to and including 4.0 should work).
   * GMP
 
 Build instructions:

--- a/include/llvm2kittel/Analysis/ConditionPropagator.h
+++ b/include/llvm2kittel/Analysis/ConditionPropagator.h
@@ -45,7 +45,11 @@ public:
         return m_map;
     }
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "ConditionPropagator";
     }

--- a/include/llvm2kittel/Analysis/LoopConditionBlocksCollector.h
+++ b/include/llvm2kittel/Analysis/LoopConditionBlocksCollector.h
@@ -37,7 +37,11 @@ public:
 
     bool runOnLoop(llvm::Loop *L, llvm::LPPassManager &LPM);
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "Collect loop condition blocks";
     }

--- a/include/llvm2kittel/Analysis/LoopConditionExplicitizer.h
+++ b/include/llvm2kittel/Analysis/LoopConditionExplicitizer.h
@@ -44,7 +44,11 @@ public:
         return m_map;
     }
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "LoopConditionExplicitizer";
     }

--- a/include/llvm2kittel/Analysis/MemoryAnalyzer.h
+++ b/include/llvm2kittel/Analysis/MemoryAnalyzer.h
@@ -58,7 +58,11 @@ public:
     void visitLoadInst(llvm::LoadInst &I);
     void visitStoreInst(llvm::StoreInst &I);
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "Obtain memory alias analysis results";
     }

--- a/include/llvm2kittel/Transform/BasicBlockSorter.h
+++ b/include/llvm2kittel/Transform/BasicBlockSorter.h
@@ -35,7 +35,11 @@ public:
 
     bool runOnFunction(llvm::Function &function);
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "Bring basic blocks into topological order";
     }

--- a/include/llvm2kittel/Transform/BitcastCallEliminator.h
+++ b/include/llvm2kittel/Transform/BitcastCallEliminator.h
@@ -30,7 +30,11 @@ public:
 
     bool runOnFunction(llvm::Function &function);
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "Bitcast call elimination pass";
     }

--- a/include/llvm2kittel/Transform/ConstantExprEliminator.h
+++ b/include/llvm2kittel/Transform/ConstantExprEliminator.h
@@ -32,7 +32,11 @@ public:
 
     bool runOnFunction(llvm::Function &function);
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "ConstantExpr elimination pass";
     }

--- a/include/llvm2kittel/Transform/EagerInliner.h
+++ b/include/llvm2kittel/Transform/EagerInliner.h
@@ -18,10 +18,18 @@
   #include <llvm/IR/Function.h>
 #endif
 #include <llvm/Analysis/InlineCost.h>
+#if LLVM_VERSION < VERSION(4, 0)
 #include <llvm/Transforms/IPO/InlinerPass.h>
+#else
+#include <llvm/Transforms/IPO/Inliner.h>
+#endif
 #include "WARN_ON.h"
 
+#if LLVM_VERSION < VERSION(4, 0)
 class EagerInliner : public llvm::Inliner
+#else
+class EagerInliner : public llvm::LegacyInlinerBase
+#endif
 {
 
 public:
@@ -37,7 +45,11 @@ public:
 
     static char ID;
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "Eager function inliner";
     }

--- a/include/llvm2kittel/Transform/ExtremeInliner.h
+++ b/include/llvm2kittel/Transform/ExtremeInliner.h
@@ -18,10 +18,18 @@
   #include <llvm/IR/Function.h>
 #endif
 #include <llvm/Analysis/InlineCost.h>
+#if LLVM_VERSION < VERSION(4, 0)
 #include <llvm/Transforms/IPO/InlinerPass.h>
+#else
+#include <llvm/Transforms/IPO/Inliner.h>
+#endif
 #include "WARN_ON.h"
 
+#if LLVM_VERSION < VERSION(4, 0)
 class ExtremeInliner : public llvm::Inliner
+#else
+class ExtremeInliner : public llvm::LegacyInlinerBase
+#endif
 {
 
 public:
@@ -37,7 +45,11 @@ public:
 
     static char ID;
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "Extreme function inliner";
     }

--- a/include/llvm2kittel/Transform/Hoister.h
+++ b/include/llvm2kittel/Transform/Hoister.h
@@ -44,7 +44,11 @@ public:
 #endif
     bool doFinalization();
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "Selective Hoister";
     }

--- a/include/llvm2kittel/Transform/Mem2Reg.h
+++ b/include/llvm2kittel/Transform/Mem2Reg.h
@@ -42,7 +42,11 @@ public:
 
     virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "llvm2KITTeL's mem2reg";
     }

--- a/include/llvm2kittel/Transform/StrengthIncreaser.h
+++ b/include/llvm2kittel/Transform/StrengthIncreaser.h
@@ -28,7 +28,11 @@ public:
 
     bool runOnBasicBlock(llvm::BasicBlock &bb);
 
+#if LLVM_VERSION < VERSION(4, 0)
     virtual const char *getPassName() const
+#else
+    virtual llvm::StringRef getPassName() const
+#endif
     {
         return "Strength increaser pass";
     }

--- a/lib/Transform/EagerInliner.cpp
+++ b/lib/Transform/EagerInliner.cpp
@@ -18,7 +18,11 @@
 #endif
 
 EagerInliner::EagerInliner()
+#if LLVM_VERSION < VERSION(4, 0)
   : llvm::Inliner(ID)
+#else
+  : llvm::LegacyInlinerBase(ID)
+#endif
 {}
 
 EagerInliner::~EagerInliner()

--- a/lib/Transform/ExtremeInliner.cpp
+++ b/lib/Transform/ExtremeInliner.cpp
@@ -20,7 +20,11 @@
 #include "WARN_ON.h"
 
 ExtremeInliner::ExtremeInliner(llvm::Function *function, bool inlineVoids)
+#if LLVM_VERSION < VERSION(4, 0)
   : llvm::Inliner(ID),
+#else
+  : llvm::LegacyInlinerBase(ID),
+#endif
     m_function(function),
     m_inlineVoids(inlineVoids)
 {}


### PR DESCRIPTION
As for the LLVM 3.9 support, I only did very light testing of this. In particular I did not test (and have no real way of testing the inliner passes).

Note that LLVM 4.0 has not been released yet. There's currently an RC2.